### PR TITLE
Filtering with multiple possible values example

### DIFF
--- a/Api/Classes/ParseFIlter.cs
+++ b/Api/Classes/ParseFIlter.cs
@@ -21,4 +21,33 @@ public class ParseFilter
 
         return parsedValue;
     }
+
+    public static List<string> GetStringOptions(string key, IQueryCollection query)
+    {
+        string? value = query[key];
+
+        return value.Split("|").ToList();
+    }
+
+    public static List<int> GetNumberOptions(string key, IQueryCollection query)
+    {
+        string? value = query[key];
+        string[] values = value.Split("|");
+
+        List<int> ret = [];
+
+        int parsedValue;
+        foreach (string v in values)
+        {
+            if (!int.TryParse(v, out parsedValue))
+            {
+                // Failed parse
+                return null;
+            }
+
+            ret.Add(parsedValue);
+        }
+
+        return ret;
+    }
 }

--- a/Api/Dto/Filter/EffectFilter.cs
+++ b/Api/Dto/Filter/EffectFilter.cs
@@ -12,6 +12,8 @@ public partial class EffectFilter : IFilter<Effect>
     public int? DurationMin { get; set; }
     public int? DurationMax { get; set; }
 
+    public List<int> Value { get; set; }
+
     public dynamic? GetValue(string key)
     {
         switch (key)
@@ -21,6 +23,7 @@ public partial class EffectFilter : IFilter<Effect>
             case "vmax": return ValueMax;
             case "dmin": return DurationMin;
             case "dmax": return DurationMax;
+            case "value": return Value;
             default: return null;
         }
     }
@@ -33,7 +36,8 @@ public partial class EffectFilter : IFilter<Effect>
             ValueMin = ParseFilter.GetInt("vmin", query),
             ValueMax = ParseFilter.GetInt("vmax", query),
             DurationMin = ParseFilter.GetInt("dmin", query),
-            DurationMax = ParseFilter.GetInt("dmax", query)
+            DurationMax = ParseFilter.GetInt("dmax", query),
+            Value = ParseFilter.GetNumberOptions("value", query)
         }; ;
     }
 }

--- a/Api/Repositories/EffectRepository.cs
+++ b/Api/Repositories/EffectRepository.cs
@@ -52,6 +52,12 @@ public class EffectRepository : IRepository<Effect>, IDisposable
             effects = effects.Where(e => e.Duration <= dMax);
         }
 
+        List<int>? values = filter.GetValue("value");
+        if (values != null)
+        {
+            effects = effects.Where(e => values!.Contains((int)e.Value));
+        }
+
         return effects;
     }
 


### PR DESCRIPTION
**NEW**
- Listing filters now has a way to parse multiple values to be or'd
- Effects "value" parameter can be or'd(as an example)